### PR TITLE
Lowered LogLevel to Warning to follow conventions

### DIFF
--- a/Extensions/Unity/Modules/FullScreen/Impl/FullScreenController.cs
+++ b/Extensions/Unity/Modules/FullScreen/Impl/FullScreenController.cs
@@ -7,8 +7,8 @@ namespace Build1.PostMVC.Extensions.Unity.Modules.FullScreen.Impl
 {
     internal sealed class FullScreenController : IFullScreenController
     {
-        [Log(LogLevel.All)] public ILog             Log        { get; set; }
-        [Inject]            public IEventDispatcher Dispatcher { get; set; }
+        [Log(LogLevel.Warning)] public ILog             Log        { get; set; }
+        [Inject]                public IEventDispatcher Dispatcher { get; set; }
 
         public bool IsInFullScreen { get; private set; }
 

--- a/Extensions/Unity/Modules/Settings/Commands/SettingsUnloadCommand.cs
+++ b/Extensions/Unity/Modules/Settings/Commands/SettingsUnloadCommand.cs
@@ -8,22 +8,22 @@ namespace Build1.PostMVC.Extensions.Unity.Modules.Settings.Commands
 {
     public sealed class SettingsUnloadCommand : Command
     {
-        [Log(LogLevel.All)] public ILog                Log                { get; set; }
-        [Inject]            public IEventDispatcher    Dispatcher         { get; set; }
-        [Inject]            public ISettingsController SettingsController { get; set; }
+        [Log(LogLevel.Warning)] public ILog                Log                { get; set; }
+        [Inject]                public IEventDispatcher    Dispatcher         { get; set; }
+        [Inject]                public ISettingsController SettingsController { get; set; }
 
         public override void Execute()
         {
             Log.Debug("Execute");
-            
+
             Retain();
 
             Dispatcher.AddListener(SettingsEvent.UnloadSuccess, OnSuccess);
             Dispatcher.AddListener(SettingsEvent.UnloadFail, OnFail);
-            
+
             SettingsController.Unload();
         }
-        
+
         private void OnSuccess()
         {
             Log.Debug("OnSuccess");


### PR DESCRIPTION
So that you can just search the whole project for `LogLevel.All` to see if you've forgot to turn something off.